### PR TITLE
Centralize API base URL configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Base URL of the backend API
+VITE_API_BASE_URL=http://localhost:8001/api

--- a/frontend/src/components/AssignmentList.vue
+++ b/frontend/src/components/AssignmentList.vue
@@ -46,6 +46,7 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
+import { API_BASE_URL } from '../config/api'
 
 const assignments = ref([])
 const error = ref(null)
@@ -53,7 +54,7 @@ const router = useRouter()
 
 async function fetchAssignments() {
   try {
-    const res = await fetch('http://localhost:8001/api/assignments')
+    const res = await fetch(`${API_BASE_URL}/assignments`)
     if (!res.ok) throw new Error('Ошибка загрузки заданий')
     assignments.value = await res.json()
   } catch (e) {
@@ -64,7 +65,7 @@ async function fetchAssignments() {
 async function deleteAssignment(id) {
   if (!confirm('Удалить задание?')) return
   try {
-    const res = await fetch(`http://localhost:8001/api/assignments/${id}`, { method: 'DELETE' })
+    const res = await fetch(`${API_BASE_URL}/assignments/${id}`, { method: 'DELETE' })
     if (!res.ok) throw new Error('Ошибка удаления')
     assignments.value = assignments.value.filter(a => a.id !== id)
   } catch (e) {

--- a/frontend/src/components/QuizEditor.vue
+++ b/frontend/src/components/QuizEditor.vue
@@ -64,6 +64,7 @@
 
 <script setup>
 import { ref, reactive, computed, onMounted } from 'vue'
+import { API_BASE_URL } from '../config/api'
 
 const props = defineProps({
   assignmentId: Number,
@@ -91,7 +92,7 @@ async function loadAssignment() {
 
   loading.value = true
   try {
-    const res = await fetch(`http://localhost:8001/api/assignments/${props.assignmentId}`)
+    const res = await fetch(`${API_BASE_URL}/assignments/${props.assignmentId}`)
     if (!res.ok) throw new Error('Ошибка загрузки задания')
     const data = await res.json()
 
@@ -173,8 +174,8 @@ async function saveAssignment() {
 
   try {
     const url = props.isEdit
-      ? `http://localhost:8001/api/assignments/${props.assignmentId}`
-      : `http://localhost:8001/api/assignments`
+      ? `${API_BASE_URL}/assignments/${props.assignmentId}`
+      : `${API_BASE_URL}/assignments`
     const method = props.isEdit ? 'PUT' : 'POST'
 
     const res = await fetch(url, {

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;


### PR DESCRIPTION
## Summary
- add `API_BASE_URL` config sourced from `VITE_API_BASE_URL`
- refactor AssignmentList and QuizEditor to use `API_BASE_URL`
- document `VITE_API_BASE_URL` in `.env.example`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1db431f908330bd9b9f2f1ba0b518